### PR TITLE
lwatch fails in a module that has project compile dependencies

### DIFF
--- a/tasks/java.js
+++ b/tasks/java.js
@@ -1,11 +1,11 @@
 'use strict';
 
-const childProcess = require('child_process');
 const configs = require('./lib/configs');
 const duration = require('gulp-duration');
 const gulp = require('gulp');
 const gutil = require('gulp-util');
 const projectDeps = require('./lib/projectDeps');
+const gradleChildProcess = require('./lib/gradleChildProcess');
 
 const buildGradleArgs = (projects) => {
 	const skippedTasks = [
@@ -27,7 +27,7 @@ gulp.task('build-java', (done) => {
 	const javaTimer = duration('java');
 	projectDeps().then((projects) => {
 		gutil.log(gutil.colors.magenta('java'), 'Compiling Java');
-		const cp = childProcess.spawn('gradle', buildGradleArgs(projects), { cwd: process.cwd() });
+		const cp = gradleChildProcess(buildGradleArgs(projects));
 		cp.stderr.pipe(process.stderr);
 		cp.on('exit', (code) => {
 			if (code === 0) {

--- a/tasks/lib/gradleChildProcess.js
+++ b/tasks/lib/gradleChildProcess.js
@@ -1,0 +1,24 @@
+const childProcess = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+module.exports = (args) => {
+	const cwd = process.cwd();
+
+	const gradleSettingsFilePath = path.join(cwd, '..', 'settings.gradle');
+
+	if (fs.existsSync(gradleSettingsFilePath)) {
+		const gradleSettingsTempFilePath = gradleSettingsFilePath + '.tmp';
+
+		fs.rename(gradleSettingsFilePath, gradleSettingsTempFilePath);
+
+		const cp = childProcess.spawn('gradle', args, { cwd });
+
+		cp.on('exit', () => fs.rename(gradleSettingsTempFilePath, gradleSettingsFilePath));
+
+		return cp;
+	}
+	else {
+		return childProcess.spawn('gradle', args, { cwd });
+	}
+}

--- a/tasks/lib/projectDeps.js
+++ b/tasks/lib/projectDeps.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const childProcess = require('child_process');
+const gradleChildProcess = require('./gradleChildProcess');
 
 module.exports = () => {
 	return new Promise((resolve, reject) => {
@@ -8,7 +8,7 @@ module.exports = () => {
 			resolve(global.projectDeps);
 		}
 		else {
-			const cp = childProcess.spawn('gradle', ['dependencies', '--configuration', 'compile'], { cwd: process.cwd() });
+			const cp = gradleChildProcess(['dependencies', '--configuration', 'compile']);
 			let gradleOutput = '';
 			cp.stdout.on('data', (data) => {
 				gradleOutput += data.toString();

--- a/tasks/lib/soyDeps.js
+++ b/tasks/lib/soyDeps.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const childProcess = require('child_process');
 const configs = require('./configs');
 const path = require('path');
+const gradleChildProcess = require('./gradleChildProcess');
 
 module.exports = () => {
 	return new Promise((resolve, reject) => {
@@ -10,7 +10,7 @@ module.exports = () => {
 			resolve(global.soyDeps);
 		}
 		else {
-			const cp = childProcess.spawn('gradle', ['dependencies', '--configuration', 'soyCompile'], { cwd: process.cwd() });
+			const cp = gradleChildProcess(['dependencies', '--configuration', 'soyCompile']);
 			let gradleOutput = '';
 			cp.stdout.on('data', (data) => {
 				gradleOutput += data.toString();


### PR DESCRIPTION
It's a generally known build issue that gradle chokes on modules that compile other modules at build time (instead of using a published jar).  Now that lwatch is using gradle, it runs into that same build issue when I try to start it up.

Sample output when run from `users-admin-web`:
```
[16:31:20] configs { globClass: 'classes/**/*.class',
  globJava: 'src/main/java/**/*.java',
  globJs: 'src/main/resources/META-INF/resources/**/*.js',
  globJsp: 'src/main/resources/META-INF/resources/**/*.jsp',
  globSass: 'src/main/resources/META-INF/resources/**/*.scss',
  globSoy: 'src/main/resources/META-INF/resources/**/*.soy',
  gogoPort: 11311,
  pathExploded: 'build/exploded' }
There was an error reading package.json

FAILURE: Build failed with an exception.

* Where:
Build file '/Users/drewbrokke/Documents/liferay/liferay-portal/modules/apps/foundation/users-admin/users-admin-impl/build.gradle' line: 10

* What went wrong:
A problem occurred evaluating project ':apps:foundation:users-admin:users-admin-impl'.
> Project with path ':apps:web-experience:export-import:export-import-service' could not be found in project ':apps:foundation:users-admin:users-admin-impl'.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.
(node:14588) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error: Unable to call gardle to get soy dependencies.
```

One way to get around this issue is to delete, move, or rename the parent directory's `settings.gradle` file whenever running a gradle command.  We could do something like that pretty easily here.